### PR TITLE
Do not merge PR automatically

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -46,6 +46,8 @@ jobs:
         run: git merge upstream/master --no-edit
       
       - name: Push to wiki source repo
+        # Do not push to main@source_repo in case of a PR or that would automatically merge the PR!
+        if: ${{ github.event_name == 'push' }}
         run: git push origin HEAD:main
       
       - name: Push to destination


### PR DESCRIPTION
I disabled the push done to main by the CI build triggered from a PR. That had the effect of effectively pushing the changes to main, which is the same as merging the PR...