### PR TITLE
Do not merge with actual wiki on PR CI builds

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -51,7 +51,7 @@ jobs:
       
       - name: Push to wiki source repo
         # Do not push to main@source_repo in case of a PR or that would automatically merge the PR!
-        if: ${{ github.event_name == 'push' }} || ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
         run: git push origin HEAD:main
       
       - name: Push to destination


### PR DESCRIPTION
There was an error in a condition performing the push to the main branch during a CI build triggered by a PR. That caused the main branch to be automatically updated with the content of the PR.